### PR TITLE
Remove duplicate redis installation

### DIFF
--- a/ansible/roles/common/vars/main.yml
+++ b/ansible/roles/common/vars/main.yml
@@ -17,4 +17,3 @@ required_packages:
     - python-dev
     - libevent-dev
     - libpq-dev
-    - redis-server


### PR DESCRIPTION
Redis is already installed in `ansible/roles/webapp/tasks/redis.yml`
