### PR TITLE
Run Celery beat in production

### DIFF
--- a/_lib/frontend_tmux.yml
+++ b/_lib/frontend_tmux.yml
@@ -6,3 +6,4 @@ windows:
   - window_name: celery worker
     panes:
       - .env/bin/celery -A flask_app.tasks worker --loglevel=info
+      - .env/bin/celery -A flask_app.tasks shell

--- a/ansible/roles/webapp/templates/supervisor.j2
+++ b/ansible/roles/webapp/templates/supervisor.j2
@@ -20,3 +20,14 @@ stdout_logfile_maxbytes=50MB
 stdout_logfile_backups=3
 stdout_events_enabled=true
 redirect_stderr=true
+
+[program:{{app_name}}-beat]
+process_name={{app_name}}-beat
+directory={{deploy_root}}
+command={{celery_bin}} -A flask_app.tasks beat --loglevel=info
+user={{user_name or app_name}}
+stdout_logfile=/var/log/{{app_name}}-beat.log
+stdout_logfile_maxbytes=50MB
+stdout_logfile_backups=3
+stdout_events_enabled=true
+redirect_stderr=true


### PR DESCRIPTION
I added "shell" and not "beat" in tmux since it doesn't make much sense to actually wait your tasks to arrive when developing.
